### PR TITLE
Add MS Word SASGF 2021 template

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -6,4 +6,4 @@ Watch this space for templates you can use to create your paper in Word or LaTex
 
 Ol' trusty. The go to word processing application for millions around the world and many SAS Global Forum authors. This is the official SAS Global Forum 2021 Word document template.
 
-Download it [here](./word/SASGF2021-Proceedings-Paper-Template.docx).
+Download it [here](https://github.com/sascommunities/sas-global-forum-2021/raw/main/templates/word/SASGF2021-Proceedings-Paper-Template.docx).

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,3 +1,9 @@
 # Templates for SAS Global Forum 2021
 
 Watch this space for templates you can use to create your paper in Word or LaTex.  We'll also have a template for Jupyter Notebook and instructions for how to submit these for publication.
+
+## Word
+
+Ol' trusty. The go to word processing application for millions around the world and many SAS Global Forum authors. This is the official SAS Global Forum 2021 Word document template.
+
+Download it [here](./word/SASGF2021-Proceedings-Paper-Template.docx).


### PR DESCRIPTION
This branch/commit adds the official SAS Global Forum 2021 Word template to a new folder call "word" as a sub-folder of the templates directory. In addition, a (presumptuous) link and short description of the template has been added to the templates directory README.

I have written the new section of the README in a relatively jovial way. Feel free to edit or kick it back to me if you think it needs to be more formal.

As an aside to this PR specifically, and perhaps its obvious from this initial commit, I am going to create separate PRs for each of the different types (Word, Jupyter, Latex).