### PR TITLE
Updates for viewing PDFs on gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,9 @@
 tasks:
   - init: export PIP_USER=false && python3 -m pip install --upgrade pip 
-  
+
 image:
   file: .gitpod.dockerfile
 vscode:
   extensions:
     - sasjs.sasjs-for-vscode
-
-    
+    - cweijan.vscode-office

--- a/tools/notebook-to-pdf/README.md
+++ b/tools/notebook-to-pdf/README.md
@@ -32,7 +32,7 @@ From the command line: `python app.py`
 
 ```bash
 git clone https://github.com/sascommunities/sas-global-forum-2021
-cd tools/notebook-to-pdf
+cd sas-global-forum-2021/tools/notebook-to-pdf
 python3 -m venv env
 . env/bin/activate
 pip install -r requirements.txt

--- a/tools/notebook-to-pdf/README.md
+++ b/tools/notebook-to-pdf/README.md
@@ -32,10 +32,9 @@ From the command line: `python app.py`
 
 ```bash
 git clone https://github.com/sascommunities/sas-global-forum-2021
-cd sas-global-forum-2021/tools/notebook-to-pdf
+cd tools/notebook-to-pdf
 python3 -m venv env
 . env/bin/activate
-export PIP_USER=false # if a gitpod env
 pip install -r requirements.txt
 python3 app.py --markdown-file /workspace/sas-global-forum-2021/tools/notebook-to-pdf/DEMO.md --output-dir /tmp
 ```


### PR DESCRIPTION
Adding an extra package so that the generated PDF can also be opened in gitpod.

Removing a gitpod specific line of code that is now redundant, as it is set in the .gitpod.yml